### PR TITLE
Bower registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,6 @@
   "ignore": [
     "**/.*",
     "component.json",
-    "example/*"
+    "example"
   ]
 }


### PR DESCRIPTION
Hello, there!

I've added a Bower file and registered it on bower's registry so people can `bower install veinjs` properly.

For now it is registered to point to my fork, as it already contains the _bower.json_ file, but as soon as this pull request gets merged, I'll try and change the endpoint at bower so to point to your repository.
