### PR TITLE
Recreate style element if #vein does not exist

### DIFF
--- a/vein.js
+++ b/vein.js
@@ -74,7 +74,7 @@
         var self = this,
             si, sl;
 
-        if(!self.element) {
+        if(!self.element || !document.getElementById('vein')) {
             self.element = document.createElement("style");
             self.element.setAttribute('type', 'text/css');
             self.element.setAttribute('id', 'vein');


### PR DESCRIPTION
Recreate style element if #vein does not exist in cases where it has manually been removed *after* veinjs triggered the first time.